### PR TITLE
Reduce the default number of workers in the CLI

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -16,7 +16,7 @@ from core.maskers import Masker, MicasenseRedEdgeThresholdMasker, P4MSThresholdM
 
 
 class CLI(object):
-    def __init__(self, max_workers: int = os.cpu_count() * 5):
+    def __init__(self, max_workers: int = os.cpu_count()):
         """Command Line Interface Class for glint mask generators.
 
         Parameters


### PR DESCRIPTION
The default worker count is 5 * the cpu count and may cause out of memory errors. Reduce to just cpu_count workers.