### PR TITLE
Reduce default number of workers

### DIFF
--- a/glint_mask_generator/cli.py
+++ b/glint_mask_generator/cli.py
@@ -15,7 +15,7 @@ from .maskers import Masker, MicasenseRedEdgeThresholdMasker, P4MSThresholdMaske
 
 
 class CLI(object):
-    def __init__(self, max_workers: int = os.cpu_count()):
+    def __init__(self, max_workers: int = min(4, os.cpu_count())):
         """Command Line Interface Class for glint mask generators.
 
         Parameters

--- a/gui/__main__.py
+++ b/gui/__main__.py
@@ -88,7 +88,7 @@ class GlintMaskGenerator(QtWidgets.QMainWindow):
         print("Multithreading with maximum %d threads" % self.threadpool.maxThreadCount())
 
         # Set max workers to good default
-        self.max_workers = os.cpu_count()
+        self.max_workers = min(4, os.cpu_count())
 
         # Connect signals/slots
         self.run_btn.released.connect(self.run_btn_clicked)


### PR DESCRIPTION
Currently, the default number of works is equal to the CPU count. This is sometimes an issue since modern CPUs with e.g. 12 cores will cause all memory to be consumed and the program to crash with the default config.

This PR reduces the default number of processes to`min(4, os.cpu_count())`